### PR TITLE
adding option to update category id.

### DIFF
--- a/src/core/arrow.rs
+++ b/src/core/arrow.rs
@@ -289,6 +289,10 @@ where
         &self.id
     }
 
+    fn update_category_id(&mut self, new_id: ObjectId) {
+        todo!()
+    }
+
     fn add_object(&mut self, object: Rc<Self::Object>) -> Result<Rc<Self::Morphism>, Errors> {
         todo!()
     }

--- a/src/core/base_category.rs
+++ b/src/core/base_category.rs
@@ -84,6 +84,10 @@ impl<Object: CategoryTrait + Hash + Eq + DynClone + std::clone::Clone> CategoryT
         &self.id
     }
 
+    fn update_category_id(&mut self, new_id: ObjectId) {
+        self.id = new_id;
+    }
+
     fn add_object(&mut self, object: Rc<Self::Object>) -> Result<Rc<Self::Morphism>, Errors> {
         if self.objects.contains_key(object.category_id()) {
             return Err(Errors::ObjectAlreadyExists);

--- a/src/core/discrete_category.rs
+++ b/src/core/discrete_category.rs
@@ -81,6 +81,10 @@ impl CategoryTrait for DiscreteCategory {
         &self.category_id
     }
 
+    fn update_category_id(&mut self, new_id: ObjectId) {
+        self.category_id = new_id;
+    }
+
     fn add_object(&mut self, object: Rc<Self::Object>) -> Result<Rc<Self::Morphism>, Errors> {
         let identity_morphism = Morphism::new_identity(object.clone());
         if let Some(cells) = &mut self.cells {

--- a/src/core/dynamic_category.rs
+++ b/src/core/dynamic_category.rs
@@ -186,6 +186,10 @@ impl CategoryTrait for DynamicCategory {
         self.id()
     }
 
+    fn update_category_id(&mut self, new_id: ObjectId) {
+        self.inner_category_mut().update_category_id(new_id);
+    }
+
     fn add_object(&mut self, object: Rc<DynamicCategory>) -> Result<Rc<Self::Morphism>, Errors> {
         self.inner_category_mut().add_object(object)
     }

--- a/src/core/epic_monic_category.rs
+++ b/src/core/epic_monic_category.rs
@@ -162,6 +162,10 @@ where
         self.category.category_id()
     }
 
+    fn update_category_id(&mut self, new_id: ObjectId) {
+        self.category.update_category_id(new_id);
+    }
+
     fn add_object(&mut self, object: Rc<Self::Object>) -> Result<Rc<Self::Morphism>, Errors> {
         self.category.add_object(object)
     }

--- a/src/core/traits/category_trait.rs
+++ b/src/core/traits/category_trait.rs
@@ -52,6 +52,15 @@ pub trait CategoryTrait: Debug + Any + DynClone {
 
     fn category_id(&self) -> &ObjectId;
 
+    /*
+    This should be used very carefully, as changing the category ID might lead to inconsistencies
+    it should only be used in scenarios of creating a new category based on an existing
+     */
+    fn update_category_id(&mut self, new_id: ObjectId);
+    fn update_category_id_generate(&mut self) {
+        self.update_category_id(ObjectId::generate())
+    }
+
     fn equal_to(&self, other: &Self::Object) -> bool {
         self.category_id() == other.category_id()
     }

--- a/src/core/unit/unit_category.rs
+++ b/src/core/unit/unit_category.rs
@@ -35,6 +35,10 @@ impl CategoryTrait for UnitCategory {
         todo!()
     }
 
+    fn update_category_id(&mut self, new_id: ObjectId) {
+        todo!()
+    }
+
     fn add_object(&mut self, object: Rc<Self::Object>) -> Result<Rc<Self::Morphism>, Errors> {
         todo!()
     }


### PR DESCRIPTION
To be used when recreating a new category from an existing one, by cloning then updating the id.